### PR TITLE
Add missing cancel job not found test

### DIFF
--- a/crux-agent/tests/test_api.py
+++ b/crux-agent/tests/test_api.py
@@ -78,4 +78,11 @@ def test_job_not_found(client):
     """Test job status for non-existent job."""
     response = client.get("/api/v1/jobs/non-existent-job-id")
     # Would be 404 if Redis is running, 500 otherwise
-    assert response.status_code in [404, 500] 
+    assert response.status_code in [404, 500]
+
+
+def test_cancel_job_not_found(client):
+    """Test cancelling a non-existent job."""
+    response = client.delete("/api/v1/jobs/non-existent-job-id")
+    # Would be 404 if Redis is running, 500 otherwise
+    assert response.status_code in [404, 500]


### PR DESCRIPTION
## Summary
- extend API tests with test_cancel_job_not_found

## Testing
- `pytest -q` *(fails: ImportError cannot import name 'get_current_user_from_api_key')*

------
https://chatgpt.com/codex/tasks/task_e_688156e5358083339c03e8e643c47079