### PR TITLE
Add API key verification and rate limiter

### DIFF
--- a/crux-agent/app/api/dependencies.py
+++ b/crux-agent/app/api/dependencies.py
@@ -63,3 +63,78 @@ async def get_provider(
     except Exception as e:
         logger.error(f"Failed to create provider: {e}")
         raise
+
+
+# ---------------------------------------------------------------------------
+# API key verification and user lookup
+# ---------------------------------------------------------------------------
+
+# In a real application these would likely be stored in a database or
+# environment variable.  For the purposes of this project we keep a simple
+# in-memory mapping of API keys to user information.
+_API_KEY_DB = {
+    "valid-key": {"id": "user-1", "name": "Test User"},
+}
+
+
+async def verify_api_key(request: Request) -> None:
+    """Validate that the request contains a valid API key."""
+
+    api_key = request.headers.get("X-API-Key")
+    if not api_key or api_key not in _API_KEY_DB:
+        logger.warning("Invalid or missing API key")
+        from fastapi import HTTPException, status
+
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid API key",
+        )
+
+    # store for downstream dependencies
+    request.state.api_key = api_key
+
+
+async def get_current_user_from_api_key(request: Request) -> dict:
+    """Return minimal user information extracted from the API key."""
+
+    api_key = getattr(request.state, "api_key", None)
+    user = _API_KEY_DB.get(api_key)
+    return user or {"id": "anonymous"}
+
+
+# ---------------------------------------------------------------------------
+# Rate limiter
+# ---------------------------------------------------------------------------
+
+import time
+from collections import defaultdict
+from fastapi import HTTPException, status
+
+_RATE_LIMIT = 5  # requests per minute per API key
+_rate_counter: defaultdict[tuple[str, int], int] = defaultdict(int)
+
+
+async def rate_limiter_standard(request: Request) -> None:
+    """Simple in-memory rate limiter."""
+
+    api_key = getattr(request.state, "api_key", request.client.host)
+    now = int(time.time() / 60)  # minute window
+    key = (api_key, now)
+    _rate_counter[key] += 1
+    if _rate_counter[key] > _RATE_LIMIT:
+        logger.warning(f"Rate limit exceeded for {api_key}")
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Rate limit exceeded",
+        )
+
+
+__all__ = [
+    "get_redis",
+    "get_celery",
+    "get_request_id",
+    "get_provider",
+    "verify_api_key",
+    "get_current_user_from_api_key",
+    "rate_limiter_standard",
+]

--- a/crux-agent/tests/test_api.py
+++ b/crux-agent/tests/test_api.py
@@ -1,6 +1,8 @@
 """
 Basic API tests for Crux Agent.
 """
+import os
+os.environ.setdefault("OPENAI_API_KEY", "test")
 import pytest
 from fastapi.testclient import TestClient
 
@@ -37,15 +39,27 @@ def test_health_endpoint(client):
 def test_basic_solve_validation(client):
     """Test basic solve endpoint validation."""
     # Missing question
-    response = client.post("/api/v1/solve/basic", json={})
+    response = client.post(
+        "/api/v1/solve/basic",
+        json={},
+        headers={"X-API-Key": "valid-key"},
+    )
     assert response.status_code == 422
     
     # Empty question
-    response = client.post("/api/v1/solve/basic", json={"question": ""})
+    response = client.post(
+        "/api/v1/solve/basic",
+        json={"question": ""},
+        headers={"X-API-Key": "valid-key"},
+    )
     assert response.status_code == 422
     
     # Valid request (would fail without proper API keys)
-    response = client.post("/api/v1/solve/basic", json={"question": "What is 2+2?"})
+    response = client.post(
+        "/api/v1/solve/basic",
+        json={"question": "What is 2+2?"},
+        headers={"X-API-Key": "valid-key"},
+    )
     # Should be 500 if no API keys configured, or 200 if they are
     assert response.status_code in [200, 500]
 
@@ -56,11 +70,12 @@ def test_enhanced_solve_validation(client):
     response = client.post(
         "/api/v1/solve/enhanced",
         json={
-            "question": "Test question", 
+            "question": "Test question",
             "suggested_specializations": ["symbolic integration", "calculus"],
             "professor_max_iters": 3,
             "specialist_max_iters": 2
-        }
+        },
+        headers={"X-API-Key": "valid-key"},
     )
     # Should be 500 if no API keys configured, or 200 if they are
     assert response.status_code in [200, 500]
@@ -68,7 +83,8 @@ def test_enhanced_solve_validation(client):
     # Valid request without suggested specializations (Professor decides dynamically)
     response = client.post(
         "/api/v1/solve/enhanced",
-        json={"question": "Test question"}
+        json={"question": "Test question"},
+        headers={"X-API-Key": "valid-key"},
     )
     # Should be 500 if no API keys configured, or 200 if they are
     assert response.status_code in [200, 500]
@@ -76,6 +92,9 @@ def test_enhanced_solve_validation(client):
 
 def test_job_not_found(client):
     """Test job status for non-existent job."""
-    response = client.get("/api/v1/jobs/non-existent-job-id")
+    response = client.get(
+        "/api/v1/jobs/non-existent-job-id",
+        headers={"X-API-Key": "valid-key"},
+    )
     # Would be 404 if Redis is running, 500 otherwise
-    assert response.status_code in [404, 500] 
+    assert response.status_code in [404, 500]

--- a/crux-agent/tests/test_dependencies.py
+++ b/crux-agent/tests/test_dependencies.py
@@ -1,0 +1,45 @@
+import pytest
+from fastapi import Request, HTTPException
+
+from app.api import dependencies
+
+
+def make_request(api_key: str | None = None) -> Request:
+    headers = []
+    if api_key is not None:
+        headers.append((b"x-api-key", api_key.encode()))
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "headers": headers,
+        "client": ("test", 1234),
+    }
+    return Request(scope, receive=lambda: None)
+
+
+@pytest.mark.asyncio
+async def test_verify_api_key_success():
+    req = make_request("valid-key")
+    await dependencies.verify_api_key(req)
+    assert req.state.api_key == "valid-key"
+    user = await dependencies.get_current_user_from_api_key(req)
+    assert user["id"] == "user-1"
+
+
+@pytest.mark.asyncio
+async def test_verify_api_key_failure():
+    req = make_request("bad-key")
+    with pytest.raises(HTTPException):
+        await dependencies.verify_api_key(req)
+
+
+@pytest.mark.asyncio
+async def test_rate_limiter_standard():
+    dependencies._rate_counter.clear()
+    req = make_request("valid-key")
+    req.state.api_key = "valid-key"
+    for _ in range(dependencies._RATE_LIMIT):
+        await dependencies.rate_limiter_standard(req)
+    with pytest.raises(HTTPException):
+        await dependencies.rate_limiter_standard(req)


### PR DESCRIPTION
## Summary
- implement API key validation, user lookup and in-memory rate limiting
- export helpers from dependencies
- update API tests with new authentication requirement
- add unit tests for dependency helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688156e304d48333a925ae4fde46f2d0